### PR TITLE
Add ability to compare relationship properties to null

### DIFF
--- a/src/IQToolkit.Data/Common/Language/SqlFormatter.cs
+++ b/src/IQToolkit.Data/Common/Language/SqlFormatter.cs
@@ -421,7 +421,7 @@ namespace IQToolkit.Data.Common
             }
             else
             {
-                throw new NotSupportedException(string.Format("The construtor for '{0}' is not supported", nex.Constructor.DeclaringType));
+                throw new NotSupportedException(string.Format("The constructor for '{0}' is not supported", nex.Constructor.DeclaringType));
             }
         }
 
@@ -431,7 +431,12 @@ namespace IQToolkit.Data.Common
             switch (u.NodeType)
             {
                 case ExpressionType.Not:
-                    if (IsBoolean(u.Operand.Type) || op.Length > 1)
+                    if (u.Operand is IsNullExpression)
+                    {
+                        this.Visit(((IsNullExpression)u.Operand).Expression);
+                        this.Write(" IS NOT NULL");
+                    }
+                    else if (IsBoolean(u.Operand.Type) || op.Length > 1)
                     {
                         this.Write(op);
                         this.Write(" ");

--- a/src/Test.Common/NorthwindExecutionTests.cs
+++ b/src/Test.Common/NorthwindExecutionTests.cs
@@ -1672,6 +1672,38 @@ namespace Test
             Assert.Equal(90, n);
         }
 
+        public void TestRelationshipEqualNull()
+        {
+            var q = db.Orders.Where(o => o.Customer == null);
+            Assert.Equal(true, this.GetProvider().GetQueryText(q.Expression).Contains("IS NULL"));
+            var n = q.Count();
+            Assert.Equal(0, n);
+        }
+
+        public void TestRelationshipEqualNullReversed()
+        {
+            var q = db.Orders.Where(o => null == o.Customer);
+            Assert.Equal(true, this.GetProvider().GetQueryText(q.Expression).Contains("IS NULL"));
+            var n = q.Count();
+            Assert.Equal(0, n);
+        }
+
+        public void TestRelationshipNotEqualNull()
+        {
+            var q = db.Orders.Where(o => o.Customer != null);
+            Assert.Equal(true, this.GetProvider().GetQueryText(q.Expression).Contains("IS NOT NULL"));
+            var n = q.Count();
+            Assert.Equal(830, n);
+        }
+
+        public void TestRelationshipNotEqualNullReversed()
+        {
+            var q = db.Orders.Where(o => null != o.Customer);
+            Assert.Equal(true, this.GetProvider().GetQueryText(q.Expression).Contains("IS NOT NULL"));
+            var n = q.Count();
+            Assert.Equal(830, n);
+        }
+
         public void TestConditionalResultsArePredicates()
         {
             bool value = db.Orders.Where(c => c.CustomerID == "ALFKI").Max(c => (c.CustomerID == "ALFKI" ? string.Compare(c.CustomerID, "POTATO") < 0 : string.Compare(c.CustomerID, "POTATO") > 0));

--- a/src/Test.Common/NorthwindTranslationTests.cs
+++ b/src/Test.Common/NorthwindTranslationTests.cs
@@ -84,6 +84,34 @@ namespace Test
                 );
         }
 
+        public void TestCompareRelationshipEqualNull()
+        {
+            TestQuery(
+                db.Orders.Where(o => o.Customer == null)
+                );
+        }
+
+        public void TestCompareRelationshipEqualNullReversed()
+        {
+            TestQuery(
+                db.Orders.Where(o => null == o.Customer)
+                );
+        }
+
+        public void TestCompareRelationshipNotEqualNull()
+        {
+            TestQuery(
+                db.Orders.Where(o => o.Customer != null)
+                );
+        }
+
+        public void TestCompareRelationshipNotEqualNullReversed()
+        {
+            TestQuery(
+                db.Orders.Where(o => null != o.Customer)
+                );
+        }
+
         public void TestSelectScalar()
         {
             TestQuery(db.Customers.Select(c => c.City));


### PR DESCRIPTION
This ability got broken when outer-join expressions were added.
Added tests to verify.
