### PR TITLE
Update Parameterizer.cs

### DIFF
--- a/src/IQToolkit.Data/Common/Translation/Parameterizer.cs
+++ b/src/IQToolkit.Data/Common/Translation/Parameterizer.cs
@@ -67,8 +67,8 @@ namespace IQToolkit.Data.Common
                 ColumnExpression c = (ColumnExpression)right;
                 left = new NamedValueExpression(nv.Name, c.QueryType, nv.Value);
             }
-            else if (b.Right.NodeType == (ExpressionType)DbExpressionType.NamedValue
-             && b.Left.NodeType == (ExpressionType)DbExpressionType.Column)
+            else if (right.NodeType == (ExpressionType)DbExpressionType.NamedValue
+             && left.NodeType == (ExpressionType)DbExpressionType.Column)
             {
                 NamedValueExpression nv = (NamedValueExpression)right;
                 ColumnExpression c = (ColumnExpression)left;


### PR DESCRIPTION
The second comparison used expressions from input parameter b (b.Right, b.Left) instead the local ones (left, right).
Therefore DbType of param was not adjusted to DbType of column.
