### PR TITLE
Create a new ColumnAttribute IsReadOnly for ColumnMapping

### DIFF
--- a/src/IQToolkit.Data/Common/Mapping/BasicMapping.cs
+++ b/src/IQToolkit.Data/Common/Mapping/BasicMapping.cs
@@ -124,6 +124,16 @@ namespace IQToolkit.Data.Common
         {
             return false;
         }
+        
+        /// <summary>
+        /// Determines if a property should not be written back to database
+        /// </summary>
+        /// <param name="member"></param>
+        /// <returns></returns>
+        public virtual bool IsReadOnly(MappingEntity entity, MemberInfo member)
+        {
+            return false;
+        }
 
         /// <summary>
         /// Determines if a property can be part of an update operation
@@ -133,7 +143,7 @@ namespace IQToolkit.Data.Common
         /// <returns></returns>
         public virtual bool IsUpdatable(MappingEntity entity, MemberInfo member)
         {
-            return !this.IsPrimaryKey(entity, member);
+            return !this.IsPrimaryKey(entity, member) && !this.IsReadOnly(entity, member);   
         }
 
         /// <summary>
@@ -691,7 +701,7 @@ namespace IQToolkit.Data.Common
         {
             var tableAlias = new TableAlias();
             var table = new TableExpression(tableAlias, entity, this.mapping.GetTableName(entity));
-            var assignments = this.GetColumnAssignments(table, instance, entity, (e, m) => !this.mapping.IsGenerated(e, m));
+            var assignments = this.GetColumnAssignments(table, instance, entity, (e, m) => !(mapping.IsGenerated(e, m) || mapping.IsReadOnly(e,m)));   // #MLCHANGE
 
             if (selector != null)
             {

--- a/src/IQToolkit.Data/Mapping/AttributeMapping.cs
+++ b/src/IQToolkit.Data/Mapping/AttributeMapping.cs
@@ -249,6 +249,12 @@ namespace IQToolkit.Data.Mapping
             AttributeMappingMember mm = ((AttributeMappingEntity)entity).GetMappingMember(member.Name);
             return mm != null && mm.Column != null && mm.Column.IsGenerated;
         }
+        
+        public override bool IsReadOnly(MappingEntity entity, MemberInfo member)
+        {
+            AttributeMappingMember mm = ((AttributeMappingEntity)entity).GetMappingMember(member.Name);
+            return mm != null && mm.Column != null && mm.Column.IsReadOnly;
+        }
 
         public override bool IsPrimaryKey(MappingEntity entity, MemberInfo member)
         {

--- a/src/IQToolkit.Data/Mapping/AttributeMapping.cs
+++ b/src/IQToolkit.Data/Mapping/AttributeMapping.cs
@@ -53,6 +53,7 @@ namespace IQToolkit.Data.Mapping
         public bool IsComputed { get; set; }
         public bool IsPrimaryKey { get; set; }
         public bool IsGenerated { get; set; }
+        public bool IsReadOnly { get; set; }  
     }
 
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = true)]


### PR DESCRIPTION
When a column is decorated with the new attribute IsReadOnly 
its value is is ignored for inserts or updates

Example Usage:
[Column(Member = "ROWID", IsReadOnly = true)]
