### PR TITLE
Adding nuspec files

### DIFF
--- a/nuget/IQToolkitEx.MySqlClient.nuspec
+++ b/nuget/IQToolkitEx.MySqlClient.nuspec
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>IQToolkitEx.MySqlClient</id>
+        <version>1.0.0.1</version>
+        <title>IQueryable Toolkit MySql Client Query Provider</title>
+        <authors>Matt Warren</authors>
+        <owners>Matt Warren</owners>
+        <projectUrl>https://github.com/mattwar/iqtoolkit</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>IQToolkit MySql Client Library</description>
+        <copyright />
+        <dependencies>
+            <dependency id="IQToolkitEx" />
+            <dependency id="MySql.Data" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\bin\Release\IQToolkit.Data.MySqlClient.dll" target="lib\net45\IQToolkit.Data.MySqlClient.dll" />
+    </files>
+</package>

--- a/nuget/IQToolkitEx.SQLiteClient.nuspec
+++ b/nuget/IQToolkitEx.SQLiteClient.nuspec
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>IQToolkitEx.SQLiteClient</id>
+        <version>1.0.0.1</version>
+        <title>IQueryable Toolkit SQLite Client Query Provider</title>
+        <authors>Matt Warren</authors>
+        <owners>Matt Warren</owners>
+        <projectUrl>https://github.com/mattwar/iqtoolkit</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>IQToolkit SQLite Client Library</description>
+        <copyright />
+        <dependencies>
+            <dependency id="IQToolkitEx" />
+            <dependency id="System.Data.SQLite.Core" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\bin\Release\IQToolkit.Data.SQLite.dll" target="lib\net45\IQToolkit.Data.SQLite.dll" />
+    </files>
+</package>

--- a/nuget/IQToolkitEx.SqlClient.nuspec
+++ b/nuget/IQToolkitEx.SqlClient.nuspec
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>IQToolkitEx.SqlClient</id>
+        <version>1.0.0.1</version>
+        <title>IQueryable Toolkit MS SQL Client Query Provider</title>
+        <authors>Matt Warren</authors>
+        <owners>Matt Warren</owners>
+        <projectUrl>https://github.com/mattwar/iqtoolkit</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>IQToolkit MS SQL Client Library</description>
+        <copyright />
+        <dependencies>
+            <dependency id="IQToolkitEx" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\bin\Release\IQToolkit.Data.SqlClient.dll" target="lib\net45\IQToolkit.Data.SqlClient.dll" />
+    </files>
+</package>

--- a/nuget/IQToolkitEx.SqlServerCeClient.nuspec
+++ b/nuget/IQToolkitEx.SqlServerCeClient.nuspec
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>IQToolkitEx.SqlServerCeClient</id>
+        <version>1.0.0.1</version>
+        <title>IQueryable Toolkit MS SQL CE Client Query Provider</title>
+        <authors>Matt Warren</authors>
+        <owners>Matt Warren</owners>
+        <projectUrl>https://github.com/mattwar/iqtoolkit</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>IQToolkit MS SQL Server Compact Edition Client Library</description>
+        <copyright />
+        <dependencies>
+            <dependency id="IQToolkitEx" />
+            <dependency id="Microsoft.SqlServer.Compact" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\bin\Release\IQToolkit.Data.SqlServerCe.dll" target="lib\net45\IQToolkit.Data.SqlServerCe.dll" />
+    </files>
+</package>

--- a/nuget/IQToolkitEx.nuspec
+++ b/nuget/IQToolkitEx.nuspec
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>IQToolkitEx</id>
+        <version>1.0.0.0</version>
+        <title>IQueryable Toolkit</title>
+        <authors>Matt Warren</authors>
+        <owners>Matt Warren</owners>
+        <projectUrl>https://github.com/mattwar/iqtoolkit</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Toolkit for building LINQ IQueryable providers.</description>
+        <copyright />
+    </metadata>
+    <files>
+        <file src="..\bin\Release\IQToolkit.Data.dll" target="lib\net45\IQToolkit.Data.dll" />
+        <file src="..\bin\Release\IQToolkit.dll" target="lib\net45\IQToolkit.dll" />
+    </files>
+</package>


### PR DESCRIPTION
Hey!

I noticed that the packages listed on NuGet are a bit outdated and not full. So in effort to improve this (and expose a Sqlite provider that I needed) I created a set of nuspec files that I want to share with the community. I have used the IQToolkitEx id, but you can change that easily. One significant change is combining the IQToolkit.dll with the IQToolkit.Data.dll in one nuget package. I have noticed that all query providers need access to those two assemblies and found no reason to separate them. Dependencies are now declared inside of the nuget package so that they can be installed with a single click.

Hope you find this useful!