### PR TITLE
fix MRU cache bug

### DIFF
--- a/src/IQToolkit/MostRecentlyUsedCache.cs
+++ b/src/IQToolkit/MostRecentlyUsedCache.cs
@@ -12,11 +12,11 @@ namespace IQToolkit
     /// </summary>
     public class MostRecentlyUsedCache<T>
     {
-        int maxSize;
-        List<T> list;
-        Func<T, T, bool> fnEquals;
-        ReaderWriterLockSlim rwlock;
-        int version;
+        private readonly int maxSize;
+        private readonly List<T> list;
+        private readonly Func<T, T, bool> fnEquals;
+        private readonly ReaderWriterLockSlim rwlock;
+        private int version;
 
         public MostRecentlyUsedCache(int maxSize)
             : this(maxSize, EqualityComparer<T>.Default)
@@ -70,41 +70,27 @@ namespace IQToolkit
         {
             cached = default(T);
             int cacheIndex = -1;
+
             rwlock.EnterReadLock();
             int version = this.version;
             try
             {
-                for (int i = 0, n = this.list.Count; i < n; i++)
-                {
-                    cached = this.list[i];
-                    if (fnEquals(cached, item))
-                    {
-                        cacheIndex = 0;
-                    }
-                }
+                this.FindCachedItem(item, out cached, out cacheIndex);
             }
             finally
             {
                 rwlock.ExitReadLock();
             }
+
+            // now update item in the list (only if we need to change its position or add it)
             if (cacheIndex != 0 && add)
             {
                 rwlock.EnterWriteLock();
                 try
                 {
                     // if list has changed find it again
-                    if (this.version != version)
-                    {
-                        cacheIndex = -1;
-                        for (int i = 0, n = this.list.Count; i < n; i++)
-                        {
-                            cached = this.list[i];
-                            if (fnEquals(cached, item))
-                            {
-                                cacheIndex = 0;
-                            }
-                        }
-                    }
+                    this.FindCachedItem(item, out cached, out cacheIndex);
+
                     if (cacheIndex == -1)
                     {
                         // this is first time in list, put at start
@@ -120,11 +106,13 @@ namespace IQToolkit
                             this.list.Insert(0, item);
                         }
                     }
+
                     // drop any items beyond max
                     if (this.list.Count > this.maxSize)
                     {
                         this.list.RemoveAt(this.list.Count - 1);
                     }
+
                     this.version++;
                 }
                 finally
@@ -132,7 +120,25 @@ namespace IQToolkit
                     rwlock.ExitWriteLock();
                 }
             }
+
             return cacheIndex >= 0;
+        }
+
+        private void FindCachedItem(T item, out T cached, out int index)
+        {
+            for (int i = 0, n = this.list.Count; i < n; i++)
+            {
+                cached = this.list[i];
+
+                if (fnEquals(cached, item))
+                {
+                    index = i;
+                    return;
+                }
+            }
+
+            cached = default(T);
+            index = -1;
         }
     }
 }


### PR DESCRIPTION
The MostRecentlyUsedCache implementation was not correctly identifying the cached item's index, and was never actually updating the MRU list.