### PR TITLE
fix of invalid conditional case

### DIFF
--- a/src/Test.Common/NorthwindExecutionTests.cs
+++ b/src/Test.Common/NorthwindExecutionTests.cs
@@ -1717,6 +1717,22 @@ namespace Test
             Assert.Equal(true, value);
         }
 
+        public void TestConditionalWithInvalidCase()
+        {
+            Nullable<Boolean> hasOrders = null;
+
+            var query = db.Customers.Select(r => new
+            {
+                CustomerID = r.CustomerID,
+                HasOrders = hasOrders != null
+                                  ? (bool)hasOrders
+                                  : db.Orders.Any(o => o.CustomerID.Equals(r.CustomerID))
+            });
+
+            var test = query.ToList();
+            Assert.Equal(91, test.Count());
+        }
+
         public void TestSelectManyJoined()
         {
             var cods = 


### PR DESCRIPTION
ConditionalExpressions which can be evaluated locally can be rewritten to the valid case. The invalid case will be skipped. This fixes issue #12 