### PR TITLE
Workaround to issue #17

### DIFF
--- a/src/IQToolkit.Data.Access/AccessTypeSystem.cs
+++ b/src/IQToolkit.Data.Access/AccessTypeSystem.cs
@@ -40,27 +40,27 @@ namespace IQToolkit.Data.Access
 
         public override SqlType GetSqlType(string typeName)
         {
-            if (string.Compare(typeName, "Memo", true) == 0)
+            if (string.Compare(typeName, "Memo", StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return SqlType.VarChar;
             }
-            else if (string.Compare(typeName, "Currency", true) == 0)
+            else if (string.Compare(typeName, "Currency", StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return SqlType.Decimal;
             }
-            else if (string.Compare(typeName, "ReplicationID", true) == 0)
+            else if (string.Compare(typeName, "ReplicationID", StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return SqlType.UniqueIdentifier;
             }
-            else if (string.Compare(typeName, "YesNo", true) == 0)
+            else if (string.Compare(typeName, "YesNo", StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return SqlType.Bit;
             }
-            else if (string.Compare(typeName, "LongInteger", true) == 0)
+            else if (string.Compare(typeName, "LongInteger", StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return SqlType.BigInt;
             }
-            else if (string.Compare(typeName, "VarWChar", true) == 0)
+            else if (string.Compare(typeName, "VarWChar", StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return SqlType.NVarChar;
             }

--- a/src/IQToolkit.Data.Ado/SqlTypeSystem.cs
+++ b/src/IQToolkit.Data.Ado/SqlTypeSystem.cs
@@ -9,6 +9,7 @@ using System.Text;
 namespace IQToolkit.Data
 {
     using Common;
+    using System.Globalization;
 
     /// <summary>
     /// A <see cref="QueryTypeSystem"/> for types based on <see cref="SqlType"/>.
@@ -97,7 +98,7 @@ namespace IQToolkit.Data
                     {
                         length = 80;
                     }
-                    else if (string.Compare(args[0], "max", true) == 0)
+                    else if (string.Compare(args[0], "max", StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         length = Int32.MaxValue;
                     }
@@ -113,7 +114,7 @@ namespace IQToolkit.Data
                     }
                     else
                     {
-                        precision = Int16.Parse(args[0]);
+                        precision = Int16.Parse(args[0], NumberFormatInfo.InvariantInfo);
                     }
                     if (args == null || args.Length < 2)
                     {
@@ -121,7 +122,7 @@ namespace IQToolkit.Data
                     }
                     else
                     {
-                        scale = Int16.Parse(args[1]);
+                        scale = Int16.Parse(args[1], NumberFormatInfo.InvariantInfo);
                     }
                     break;
                 case SqlType.Decimal:
@@ -131,7 +132,7 @@ namespace IQToolkit.Data
                     }
                     else
                     {
-                        precision = Int16.Parse(args[0]);
+                        precision = Int16.Parse(args[0], NumberFormatInfo.InvariantInfo);
                     }
                     if (args == null || args.Length < 2)
                     {
@@ -139,7 +140,7 @@ namespace IQToolkit.Data
                     }
                     else
                     {
-                        scale = Int16.Parse(args[1]);
+                        scale = Int16.Parse(args[1], NumberFormatInfo.InvariantInfo);
                     }
                     break;
                 case SqlType.Float:
@@ -150,7 +151,7 @@ namespace IQToolkit.Data
                     }
                     else
                     {
-                        precision = Int16.Parse(args[0]);
+                        precision = Int16.Parse(args[0], NumberFormatInfo.InvariantInfo);
                     }
                     break;
             }
@@ -278,18 +279,18 @@ namespace IQToolkit.Data
                 }
                 else
                 {
-                    sb.AppendFormat("({0})", sqlType.Length);
+                    sb.AppendFormat(NumberFormatInfo.InvariantInfo, "({0})", sqlType.Length);
                 }
             }
             else if (sqlType.Precision != 0)
             {
                 if (sqlType.Scale != 0)
                 {
-                    sb.AppendFormat("({0},{1})", sqlType.Precision, sqlType.Scale);
+                    sb.AppendFormat(NumberFormatInfo.InvariantInfo, "({0},{1})", sqlType.Precision, sqlType.Scale);
                 }
                 else
                 {
-                    sb.AppendFormat("({0})", sqlType.Precision);
+                    sb.AppendFormat(NumberFormatInfo.InvariantInfo, "({0})", sqlType.Precision);
                 }
             }
 

--- a/src/IQToolkit.Data.SQLite/SQLiteTypeSystem.cs
+++ b/src/IQToolkit.Data.SQLite/SQLiteTypeSystem.cs
@@ -12,28 +12,28 @@ namespace IQToolkit.Data.SQLite
     {
         public override SqlType GetSqlType(string typeName)
         {
-            if (string.Compare(typeName, "TEXT", true) == 0 ||
-                string.Compare(typeName, "CHAR", true) == 0 ||
-                string.Compare(typeName, "CLOB", true) == 0 ||
-                string.Compare(typeName, "VARYINGCHARACTER", true) == 0 ||
-                string.Compare(typeName, "NATIONALVARYINGCHARACTER", true) == 0)
+            if (string.Compare(typeName, "TEXT", StringComparison.OrdinalIgnoreCase) == 0 ||
+                string.Compare(typeName, "CHAR", StringComparison.OrdinalIgnoreCase) == 0 ||
+                string.Compare(typeName, "CLOB", StringComparison.OrdinalIgnoreCase) == 0 ||
+                string.Compare(typeName, "VARYINGCHARACTER", StringComparison.OrdinalIgnoreCase) == 0 ||
+                string.Compare(typeName, "NATIONALVARYINGCHARACTER", StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return SqlType.VarChar;
             }
-            else if (string.Compare(typeName, "INT", true) == 0 ||
-                string.Compare(typeName, "INTEGER", true) == 0)
+            else if (string.Compare(typeName, "INT", StringComparison.OrdinalIgnoreCase) == 0 ||
+                string.Compare(typeName, "INTEGER", StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return SqlType.BigInt;
             }
-            else if (string.Compare(typeName, "BLOB", true) == 0)
+            else if (string.Compare(typeName, "BLOB", StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return SqlType.Binary;
             }
-            else if (string.Compare(typeName, "BOOLEAN", true) == 0)
+            else if (string.Compare(typeName, "BOOLEAN", StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return SqlType.Bit;
             }
-            else if (string.Compare(typeName, "NUMERIC", true) == 0)
+            else if (string.Compare(typeName, "NUMERIC", StringComparison.OrdinalIgnoreCase) == 0)
             {
                 return SqlType.Decimal;
             }

--- a/src/IQToolkit.Data/Common/Language/SqlFormatter.cs
+++ b/src/IQToolkit.Data/Common/Language/SqlFormatter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -63,7 +64,7 @@ namespace IQToolkit.Data.Common
             get { return this.language; }
         }
 
-        protected bool HideColumnAliases 
+        protected bool HideColumnAliases
         {
             get { return this.hideColumnAliases; }
             set { this.hideColumnAliases = value; }
@@ -75,7 +76,7 @@ namespace IQToolkit.Data.Common
             set { this.hideTableAliases = value; }
         }
 
-        protected bool IsNested 
+        protected bool IsNested
         {
             get { return this.isNested; }
             set { this.isNested = value; }
@@ -790,7 +791,7 @@ namespace IQToolkit.Data.Common
                         throw new NotSupportedException(string.Format("The constant for '{0}' is not supported", value));
                     case TypeCode.Single:
                     case TypeCode.Double:
-                        string str = value.ToString();
+                        string str = ((IConvertible)value).ToString(NumberFormatInfo.InvariantInfo);
                         if (!str.Contains('.'))
                         {
                             str += ".0";
@@ -798,7 +799,7 @@ namespace IQToolkit.Data.Common
                         this.Write(str);
                         break;
                     default:
-                        this.Write(value);
+                        this.Write((value as IConvertible)?.ToString(CultureInfo.InvariantCulture) ?? value);
                         break;
                 }
             }
@@ -1113,7 +1114,7 @@ namespace IQToolkit.Data.Common
                     this.Write(")");
                 }
             }
-            else 
+            else
             {
                 this.VisitValue(@in.Expression);
                 this.Write(" IN (");

--- a/src/IQToolkit.Data/Common/Mapping/BasicMapper.cs
+++ b/src/IQToolkit.Data/Common/Mapping/BasicMapper.cs
@@ -193,7 +193,7 @@ namespace IQToolkit.Data.Common
                 if (assignment == null)
                 {
                     assignment = members.FirstOrDefault(a =>
-                        string.Compare(p.Name, a.Member.Name, true) == 0
+                        string.Compare(p.Name, a.Member.Name, StringComparison.OrdinalIgnoreCase) == 0
                         && p.ParameterType.IsAssignableFrom(a.Expression.Type));
                 }
                 if (assignment != null)
@@ -206,7 +206,7 @@ namespace IQToolkit.Data.Common
                 else
                 {
                     // find member with same name as parameter and associate it in object initializer
-                    MemberInfo mem = TypeHelper.GetDataMembers(cons.DeclaringType).Where(m => string.Compare(m.Name, p.Name, ignoreCase: true) == 0).FirstOrDefault();
+                    MemberInfo mem = TypeHelper.GetDataMembers(cons.DeclaringType).Where(m => string.Compare(m.Name, p.Name, StringComparison.OrdinalIgnoreCase) == 0).FirstOrDefault();
                     if (mem != null)
                     {
                         args[i] = Expression.Constant(TypeHelper.GetDefault(p.ParameterType), p.ParameterType);

--- a/src/IQToolkit.Data/Mapping/AttributeMapping.cs
+++ b/src/IQToolkit.Data/Mapping/AttributeMapping.cs
@@ -975,7 +975,7 @@ namespace IQToolkit.Data.Mapping
                     if (m2 != null)
                         return m2;
                 }
-                else if (this.IsColumn(entity, m) && string.Compare(this.GetColumnName(entity, m), columnName, true) == 0)
+                else if (this.IsColumn(entity, m) && string.Compare(this.GetColumnName(entity, m), columnName, StringComparison.OrdinalIgnoreCase) == 0)
                 {
                     return m;
                 }

--- a/src/Test.Common/QueryTestBase.cs
+++ b/src/Test.Common/QueryTestBase.cs
@@ -109,11 +109,11 @@ namespace Test
             {
                 if (
                     // actual name of the provider type
-                    string.Compare(this.provider.GetType().Name, exclude.Provider, true) == 0
+                    string.Compare(this.provider.GetType().Name, exclude.Provider, StringComparison.OrdinalIgnoreCase) == 0
                     // prefix of the provider type xxxQueryProvider
-                    || string.Compare(this.provider.GetType().Name, exclude.Provider + "QueryProvider", true) == 0
+                    || string.Compare(this.provider.GetType().Name, exclude.Provider + "QueryProvider", StringComparison.OrdinalIgnoreCase) == 0
                     // last name of the namespace
-                    || string.Compare(this.provider.GetType().Namespace.Split(new[] { '.' }).Last(), exclude.Provider, true) == 0
+                    || string.Compare(this.provider.GetType().Namespace.Split(new[] { '.' }).Last(), exclude.Provider, StringComparison.OrdinalIgnoreCase) == 0
                     )
                 {
                     return false;


### PR DESCRIPTION
SQL Formatter writes constant value expressions depend on current culture. Also string operations in some other classes is based on current culture. As current culture is variant based on user Environment (OS) and its options may be changed by end-user, this may lead to generating some critical errors in the formatted SQL sentence's syntax with constant values (specially with cultures with locale-specific decimal separator rather than dot '.' character).
For example when we expect `SQLFormatter` to write constant value `1.5` it may write it in windows with locale French `1,5` or locale Persian(farsi) `1/5` and therefore cannot be executed with this syntax error.