### PR TITLE
Fix issue #23 (problem with group by on predictions)

### DIFF
--- a/src/IQToolkit.Data/Common/Translation/CrossApplyRewriter.cs
+++ b/src/IQToolkit.Data/Common/Translation/CrossApplyRewriter.cs
@@ -61,7 +61,7 @@ namespace IQToolkit.Data.Common
                         {
                             Expression where = select.Where;
                             select = selectWithoutWhere;
-                            var pc = ColumnProjector.ProjectColumns(this.language, where, select.Columns, select.Alias, DeclaredAliasGatherer.Gather(select.From));
+                            var pc = ColumnProjector.ProjectColumns(this.language, ProjectionAffinity.Client, where, select.Columns, select.Alias, DeclaredAliasGatherer.Gather(select.From));
                             select = select.SetColumns(pc.Columns);
                             where = pc.Projector;
                             JoinType jt = (where == null) ? JoinType.CrossJoin : (join.Join == JoinType.CrossApply ? JoinType.InnerJoin : JoinType.LeftOuter);

--- a/src/IQToolkit.Data/Common/Translation/QueryBinder.cs
+++ b/src/IQToolkit.Data/Common/Translation/QueryBinder.cs
@@ -534,7 +534,7 @@ namespace IQToolkit.Data.Common
             }
 
             // Use ProjectColumns to get group-by expressions from key expression
-            ProjectedColumns keyProjection = this.ProjectColumns(keyExpr, projection.Select.Alias, projection.Select.Alias);
+            ProjectedColumns keyProjection = ColumnProjector.ProjectColumns(this.language, ProjectionAffinity.Server, keyExpr, null, projection.Select.Alias, projection.Select.Alias);
             var groupExprs = keyProjection.Columns.Select(c => c.Expression).ToArray();
 
             // make duplicate of source query as basis of element subquery by visiting the source again
@@ -545,7 +545,7 @@ namespace IQToolkit.Data.Common
             Expression subqueryKey = this.Visit(keySelector.Body);
 
             // use same projection trick to get group-by expressions based on subquery
-            ProjectedColumns subqueryKeyPC = this.ProjectColumns(subqueryKey, subqueryBasis.Select.Alias, subqueryBasis.Select.Alias);
+            ProjectedColumns subqueryKeyPC = ColumnProjector.ProjectColumns(this.language, ProjectionAffinity.Server, subqueryKey, null, subqueryBasis.Select.Alias, subqueryBasis.Select.Alias);
             var subqueryGroupExprs = subqueryKeyPC.Columns.Select(c => c.Expression).ToArray();
             Expression subqueryCorrelation = this.BuildPredicateWithNullsEqual(subqueryGroupExprs, groupExprs);
 
@@ -559,7 +559,7 @@ namespace IQToolkit.Data.Common
 
             // build subquery that projects the desired element
             var elementAlias = this.GetNextAlias();
-            ProjectedColumns elementPC = this.ProjectColumns(subqueryElemExpr, elementAlias, subqueryBasis.Select.Alias);
+            ProjectedColumns elementPC = ColumnProjector.ProjectColumns(this.language, ProjectionAffinity.Server, subqueryElemExpr, null, elementAlias, subqueryBasis.Select.Alias);
             ProjectionExpression elementSubquery =
                 new ProjectionExpression(
                     new SelectExpression(elementAlias, elementPC.Columns, subqueryBasis.Select, subqueryCorrelation),
@@ -595,7 +595,7 @@ namespace IQToolkit.Data.Common
                 resultExpr = Expression.Convert(resultExpr, typeof(IGrouping<,>).MakeGenericType(keyExpr.Type, subqueryElemExpr.Type));
             }
 
-            ProjectedColumns pc = this.ProjectColumns(resultExpr, alias, projection.Select.Alias);
+            ProjectedColumns pc = ColumnProjector.ProjectColumns(this.language, ProjectionAffinity.Server, resultExpr, null, alias, projection.Select.Alias);
 
             // make it possible to tie aggregates back to this group-by
             NewExpression newResult = this.GetNewExpression(pc.Projector);

--- a/src/Test.Common/NorthwindExecutionTests.cs
+++ b/src/Test.Common/NorthwindExecutionTests.cs
@@ -2029,5 +2029,28 @@ namespace Test
             Order fo = q.First();
             Assert.Equal(3, fo.Details.Count);
         }
+
+        public void TestGroupByCase1()
+        {
+            var q = db.OrderDetails.GroupBy(i => i.ProductID > 10 ? i.ProductID : 0).Select(i => new { i.Key, Count = i.Count() });
+            var qtext = this.GetProvider().GetQueryText(q.Expression);
+            var result = q.ToList();
+        }
+
+        public void TestGroupByCase2()
+        {
+            var q = db.OrderDetails.Select(i => new { key = i.ProductID > 10 ? i.ProductID : 0, i }).GroupBy(i => i.key).Select(i => new { i.Key, Count = i.Count() });
+            var qtext = this.GetProvider().GetQueryText(q.Expression);
+            var result = q.ToList();
+        }
+
+        public void TestGroupByCase3()
+        {
+            var q = db.OrderDetails.Select(i => new { key = i.ProductID > 10 ? i.ProductID : 0, i }).GroupBy(i => i.key).Select(i => new { i.Key, Count = i.Count() })
+                .Select(i => new { Computed = i.Count + i.Key });
+            var qtext = this.GetProvider().GetQueryText(q.Expression);
+            var result = q.ToList();
+        }
+
     }
 }


### PR DESCRIPTION
Fixing issue #23 (problem with group by on predictions) by setting `ProjectionAffinity` at BindGroupBy to `ProjectionAffinity.Server`. This is similar to what have been done for Distinct before. By this change the GroupBy/Case combination issue #23 will fix.
Also, at CrossApplyRewriter.cs ProjectionAffinity always must be `ProjectionAffinity.Client` because `where` is passed to the ColumnProjector as expression to finding extra columns that should be in the select expression that is passed to join.